### PR TITLE
fix(root-buttonswap-router): fixing create-pair bug in add-liquidity function

### DIFF
--- a/src/RootButtonswapRouter.sol
+++ b/src/RootButtonswapRouter.sol
@@ -31,7 +31,7 @@ contract RootButtonswapRouter is IRootButtonswapRouter {
         // create the pair if it doesn't exist yet
         address pair = IButtonswapFactory(factory).getPair(tokenA, tokenB);
         if (pair == address(0)) {
-            IButtonswapFactory(factory).createPair(tokenA, tokenB);
+            pair = IButtonswapFactory(factory).createPair(tokenA, tokenB);
         }
 
         uint256 totalA = IERC20(tokenA).balanceOf(pair);

--- a/test/BasicButtonswapRouter.t.sol
+++ b/test/BasicButtonswapRouter.t.sol
@@ -91,6 +91,11 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
 
         // Asserting one pair has been created
         assertEq(buttonswapFactory.allPairsLength(), 1);
+
+        // Asserting pair has the correct amount of tokens
+        address pair = buttonswapFactory.getPair(address(tokenA), address(tokenB));
+        assertEq(tokenA.balanceOf(pair), amountADesired);
+        assertEq(tokenB.balanceOf(pair), amountBDesired);
     }
 
     function test_addLiquidity_pairExistsNoReservoirInsufficientAAmount(


### PR DESCRIPTION
## Changes:
- Fixing a create-pair bug in add-liquidity function
  - If the zero-address has any amount of tokenA or tokenB, then it does the math as if the pair exists and reverts

## Tests:
- [x] Passes all unit tests. Can't induce the failure case because the mock-contract tokens don't allow transfer/minting to the zero-address

## Reviewers:
@Fiddlekins 