### PR TITLE
feat(router-v1): separating out create-and-add-liquidity functions

### DIFF
--- a/src/BasicButtonswapRouter.sol
+++ b/src/BasicButtonswapRouter.sol
@@ -54,6 +54,31 @@ contract BasicButtonswapRouter is RootButtonswapRouter, IBasicButtonswapRouter {
     /**
      * @inheritdoc IBasicButtonswapRouter
      */
+    function createAndAddLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        address to,
+        uint256 deadline
+    ) external virtual override ensure(deadline) returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
+        (amountA, amountB) = _createAndAddLiquidity(tokenA, tokenB, amountADesired, amountBDesired);
+        address pair = ButtonswapLibrary.pairFor(factory, tokenA, tokenB);
+        TransferHelper.safeTransferFrom(tokenA, msg.sender, address(this), amountA);
+        TransferHelper.safeApprove(tokenA, pair, amountA);
+        TransferHelper.safeTransferFrom(tokenB, msg.sender, address(this), amountB);
+        TransferHelper.safeApprove(tokenB, pair, amountB);
+
+        if (tokenA < tokenB) {
+            liquidity = IButtonswapPair(pair).mint(amountA, amountB, to);
+        } else {
+            liquidity = IButtonswapPair(pair).mint(amountB, amountA, to);
+        }
+    }
+
+    /**
+     * @inheritdoc IBasicButtonswapRouter
+     */
     function addLiquidityWithReservoir(
         address tokenA,
         address tokenB,

--- a/src/interfaces/IButtonswapRouter/IBasicButtonswapRouter.sol
+++ b/src/interfaces/IButtonswapRouter/IBasicButtonswapRouter.sol
@@ -5,7 +5,7 @@ import {IRootButtonswapRouter} from "./IRootButtonswapRouter.sol";
 
 interface IBasicButtonswapRouter is IRootButtonswapRouter {
     /**
-     * @notice Adds liquidity to a pair, creating it if it doesn't exist yet, and transfers the liquidity tokens to the recipient.
+     * @notice Adds liquidity to a pair, reverting if it doesn't exist yet, and transfers the liquidity tokens to the recipient.
      * @dev If the pair is empty, amountAMin and amountBMin are ignored.
      * If the pair is nonempty, it deposits as much of tokenA and tokenB as possible while maintaining 3 conditions:
      * 1. The ratio of tokenA to tokenB in the pair remains approximately the same
@@ -32,6 +32,32 @@ interface IBasicButtonswapRouter is IRootButtonswapRouter {
         uint256 amountAMin,
         uint256 amountBMin,
         uint16 movingAveragePrice0ThresholdBps,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);
+
+    /**
+     * @notice Adds liquidity to a pair, creating it if it doesn't exist yet, and transfers the liquidity tokens to the recipient.
+     * @dev If the pair is empty, amountAMin and amountBMin are ignored.
+     * If the pair is nonempty, it deposits as much of tokenA and tokenB as possible while maintaining 3 conditions:
+     * 1. The ratio of tokenA to tokenB in the pair remains approximately the same
+     * 2. The amount of tokenA in the pair is at least amountAMin but less than or equal to amountADesired
+     * 3. The amount of tokenB in the pair is at least amountBMin but less than or equal to amountBDesired
+     * @param tokenA The address of the first token in the pair.
+     * @param tokenB The address of the second token in the pair.
+     * @param amountADesired The maximum amount of the first token to add to the pair.
+     * @param amountBDesired The maximum amount of the second token to add to the pair.
+     * @param to The address to send the liquidity tokens to.
+     * @param deadline The time after which this transaction can no longer be executed.
+     * @return amountA The amount of tokenA actually added to the pair.
+     * @return amountB The amount of tokenB actually added to the pair.
+     * @return liquidity The amount of liquidity tokens minted.
+     */
+    function createAndAddLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
         address to,
         uint256 deadline
     ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);

--- a/src/interfaces/IButtonswapRouter/IETHButtonswapRouter.sol
+++ b/src/interfaces/IButtonswapRouter/IETHButtonswapRouter.sol
@@ -13,7 +13,7 @@ interface IETHButtonswapRouter is IBasicButtonswapRouter, IETHButtonswapRouterEr
 
     /**
      * @notice Similar to `addLiquidity` but one of the tokens is ETH wrapped into WETH.
-     * Adds liquidity to a pair, creating it if it doesn't exist yet, and transfers the liquidity tokens to the recipient.
+     * Adds liquidity to a pair, reverting if it doesn't exist yet, and transfers the liquidity tokens to the recipient.
      * @dev If the pair is empty, amountTokenMin and amountETHMin are ignored.
      * If the pair is nonempty, it deposits as much of token and WETH as possible while maintaining 3 conditions:
      * 1. The ratio of token to WETH in the pair remains approximately the same
@@ -39,6 +39,26 @@ interface IETHButtonswapRouter is IBasicButtonswapRouter, IETHButtonswapRouterEr
         address to,
         uint256 deadline
     ) external payable returns (uint256 amountToken, uint256 amountETH, uint256 liquidity);
+
+    /**
+     * @notice Similar to `creataeAndAddLiquidity` but one of the tokens is ETH wrapped into WETH.
+     * Adds liquidity to a pair, creating it if it doesn't exist yet, and transfers the liquidity tokens to the recipient.
+     * @dev If the pair is empty, amountTokenMin and amountETHMin are ignored.
+     * If the pair is nonempty, it deposits as much of token and WETH as possible while maintaining 3 conditions:
+     * 1. The ratio of token to WETH in the pair remains approximately the same
+     * 2. The amount of token in the pair is at least amountTokenMin but less than or equal to amountTokenDesired
+     * 3. The amount of WETH in the pair is at least amountETHMin but less than or equal to ETH sent
+     * @param token The address of the non-WETH token in the pair.
+     * @param amountTokenDesired The maximum amount of the non-ETH token to add to the pair.
+     * @param deadline The time after which this transaction can no longer be executed.
+     * @return amountToken The amount of token actually added to the pair.
+     * @return amountETH The amount of ETH/WETH actually added to the pair.
+     * @return liquidity The amount of liquidity tokens minted.
+     */
+    function createAndAddLiquidityETH(address token, uint256 amountTokenDesired, address to, uint256 deadline)
+        external
+        payable
+        returns (uint256 amountToken, uint256 amountETH, uint256 liquidity);
 
     /**
      * @notice Similar to `addLiquidityWithReservoir` but one of the tokens is ETH wrapped into WETH.


### PR DESCRIPTION
## Changes:
- Separating out `createAndAddLiquidity()` and `createAndAddLiquidityETH()` into separate functions

## Testing:
- [x] Added unit tests to confirm `addLiquidity()` and `addLiquidityETH()` will revert if pair DNE
- [x] Added unit tests to confirm `createAndAddLiquidity()` and `createAndAddLiquidityETH()` will create new pair
- [x] Added unit tests to confirm `createAndAddLiquidity()` and `createAndAddLiquidityETH()` will revert if pair already exists

## Reviewers:
@Fiddlekins 
