### PR TITLE
update(mock-contracts): updating mock-contracts dependency

### DIFF
--- a/test/BasicButtonswapRouter.t.sol
+++ b/test/BasicButtonswapRouter.t.sol
@@ -71,8 +71,8 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
         buttonswapFactory = new ButtonswapFactory(
             feeToSetter, isCreationRestrictedSetter, isPausedSetter, paramSetter, "LP Token", "LP"
         );
@@ -392,8 +392,8 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
         uint256 swappedA
     ) public {
         // Re-assigning tokenA and tokenB to fuzz the order of the tokens
-        tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Minting enough for minimum liquidity requirement
         poolA = bound(poolA, 10000, type(uint112).max);
@@ -1337,7 +1337,7 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1383,7 +1383,7 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1445,7 +1445,7 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1491,7 +1491,7 @@ contract BasicButtonswapRouterTest is Test, IButtonswapRouterErrors {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 

--- a/test/ButtonswapRouter.t.sol
+++ b/test/ButtonswapRouter.t.sol
@@ -74,8 +74,8 @@ contract ButtonswapRouterTest is Test, IButtonswapRouterErrors {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         address expectedPairAddress = buttonswapFactory.createPair(address(tokenA), address(tokenB));
         address pairAddress = buttonswapRouter.getPair(address(tokenA), address(tokenB));
@@ -171,7 +171,7 @@ contract ButtonswapRouterTest is Test, IButtonswapRouterErrors {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -236,7 +236,7 @@ contract ButtonswapRouterTest is Test, IButtonswapRouterErrors {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -281,8 +281,8 @@ contract ButtonswapRouterTest is Test, IButtonswapRouterErrors {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Creating the pair with poolA:poolB price ratio
         createAndInitializePair(tokenA, tokenB, poolA, poolB);
@@ -324,8 +324,8 @@ contract ButtonswapRouterTest is Test, IButtonswapRouterErrors {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Creating the pair with poolA:poolB price ratio
         (IButtonswapPair pair,) = createAndInitializePair(tokenA, tokenB, poolA, poolB);

--- a/test/ETHButtonswapRouter.t.sol
+++ b/test/ETHButtonswapRouter.t.sol
@@ -96,7 +96,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        rebasingToken = new MockRebasingERC20("RebasingToken", "rTKN", 18);
+        rebasingToken = new MockRebasingERC20("RebasingToken", "rTKN", 18, 1e36);
         weth = new MockWeth();
         buttonswapFactory = new ButtonswapFactory(
             feeToSetter, isCreationRestrictedSetter, isPausedSetter, paramSetter, "LP Token", "LP"
@@ -419,7 +419,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         uint256 swappedToken
     ) public {
         // Re-assigning token to fuzz the order of the tokens
-        rebasingToken = new MockRebasingERC20{salt: saltToken}("Rebasing Token", "rTKN", 18);
+        rebasingToken = new MockRebasingERC20{salt: saltToken}("Rebasing Token", "rTKN", 18, 1e36);
 
         // Minting enough for minimum liquidity requirement
         poolToken = bound(poolToken, 10000, type(uint112).max);
@@ -1386,7 +1386,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Key thing here is that the first token is not WETH
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1431,7 +1431,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         address[] memory path = new address[](poolOutAmounts.length);
         path[0] = address(weth);
         for (uint256 idx = 1; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1485,7 +1485,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         address[] memory path = new address[](poolOutAmounts.length);
         path[0] = address(weth);
         for (uint256 idx = 1; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1550,7 +1550,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (last token is not WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1591,7 +1591,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (last token is WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length - 1; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
         path[path.length - 1] = address(weth);
@@ -1642,7 +1642,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (last token is WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length - 1; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
         path[path.length - 1] = address(weth);
@@ -1711,7 +1711,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (last token is not WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1752,7 +1752,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (last token is WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length - 1; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
         path[path.length - 1] = address(weth);
@@ -1803,7 +1803,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (last token is WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length - 1; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
         path[path.length - 1] = address(weth);
@@ -1865,7 +1865,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         // Creating all the tokens for the path (first token is not WETH)
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1908,7 +1908,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         address[] memory path = new address[](poolOutAmounts.length);
         path[0] = address(weth);
         for (uint256 idx = 1; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 
@@ -1959,7 +1959,7 @@ contract ETHButtonswapRouterTest is Test, IButtonswapRouterErrors, IETHButtonswa
         address[] memory path = new address[](poolOutAmounts.length);
         path[0] = address(weth);
         for (uint256 idx = 1; idx < path.length; idx++) {
-            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18);
+            MockRebasingERC20 token = new MockRebasingERC20("Token", "TKN", 18, 1e36);
             path[idx] = address(token);
         }
 

--- a/test/GenericButtonswapRouter/GenericButtonswapRouterAddLiquidity.t.sol
+++ b/test/GenericButtonswapRouter/GenericButtonswapRouterAddLiquidity.t.sol
@@ -120,9 +120,9 @@ contract GenericButtonswapRouterAddLiquidityTest is Test, IGenericButtonswapRout
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
-        tokenC = new MockRebasingERC20("TokenC", "TKNC", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
+        tokenC = new MockRebasingERC20("TokenC", "TKNC", 18, 1e36);
         buttonTokenA = new MockButtonToken(address(tokenA));
         buttonTokenB = new MockButtonToken(address(tokenB));
         weth = new MockWeth();
@@ -1375,8 +1375,8 @@ contract GenericButtonswapRouterAddLiquidityTest is Test, IGenericButtonswapRout
 
     function test_addLiquidityWithReservoir_revertWhenPairDoesNotExist() public {
         // Creating new tokens to ensure the pair does not exist
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         // Creating the addLiquidityParams
         addLiquidityParams.operation = ButtonswapOperations.Liquidity.SINGLE;
@@ -1409,8 +1409,8 @@ contract GenericButtonswapRouterAddLiquidityTest is Test, IGenericButtonswapRout
 
     function test_addLiquidityWithReservoir_revertWhenPairIsNotInitialized(bytes32 saltA, bytes32 saltB) public {
         // Re-assigning tokenA and tokenB to ensure random new pair
-        tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Creating random A1-B1 pair without initializing
         address pair = buttonswapFactory.createPair(address(tokenA), address(tokenB));

--- a/test/GenericButtonswapRouter/GenericButtonswapRouterRemoveLiquidity.t.sol
+++ b/test/GenericButtonswapRouter/GenericButtonswapRouterRemoveLiquidity.t.sol
@@ -140,9 +140,9 @@ contract GenericButtonswapRouterRemoveLiquidityTest is Test, IGenericButtonswapR
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
-        tokenC = new MockRebasingERC20("TokenC", "TKNC", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
+        tokenC = new MockRebasingERC20("TokenC", "TKNC", 18, 1e36);
         buttonTokenA = new MockButtonToken(address(tokenA));
         buttonTokenB = new MockButtonToken(address(tokenB));
         weth = new MockWeth();

--- a/test/GenericButtonswapRouter/GenericButtonswapRouterSwap.t.sol
+++ b/test/GenericButtonswapRouter/GenericButtonswapRouterSwap.t.sol
@@ -16,6 +16,7 @@ import {MockWeth} from "./../mocks/MockWeth.sol";
 import {MockButtonToken} from "./../mocks/MockButtonToken.sol";
 import {IButtonswapPairErrors} from
     "buttonswap-periphery_buttonswap-core/interfaces/IButtonswapPair/IButtonswapPairErrors.sol";
+import {console} from "buttonswap-periphery_forge-std/console.sol";
 
 contract GenericButtonswapRouterSwapTest is Test, IGenericButtonswapRouterErrors {
     uint256 constant BPS = 10_000;
@@ -70,8 +71,8 @@ contract GenericButtonswapRouterSwapTest is Test, IGenericButtonswapRouterErrors
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
         buttonTokenA = new MockButtonToken(address(tokenA));
         weth = new MockWeth();
         buttonswapFactory = new ButtonswapFactory(
@@ -479,6 +480,7 @@ contract GenericButtonswapRouterSwapTest is Test, IGenericButtonswapRouterErrors
         // Estimating how much input a trade would take and making amountInMax -1 lower
         uint256 expectedAmountIn = ButtonswapLibrary.getAmountIn(amountOut, poolA, poolB);
         uint256 amountInMax = expectedAmountIn - 1;
+        vm.assume(amountInMax < tokenA.mintableBalance());
 
         // Creating swapSteps for single swap
         IGenericButtonswapRouter.SwapStep[] memory swapSteps = new IGenericButtonswapRouter.SwapStep[](1);

--- a/test/GenericButtonswapRouter/GenericButtonswapRouterUSDM.t.sol
+++ b/test/GenericButtonswapRouter/GenericButtonswapRouterUSDM.t.sol
@@ -78,7 +78,7 @@ contract GenericButtonswapRouterUSDMTest is Test, IGenericButtonswapRouterErrors
         isPausedSetter = makeAddr("isPausedSetter");
         paramSetter = makeAddr("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
         weth = new MockWeth();
         buttonswapFactory = new ButtonswapFactory(
             feeToSetter, isCreationRestrictedSetter, isPausedSetter, paramSetter, "Token Name", "SYMBOL"
@@ -142,7 +142,7 @@ contract GenericButtonswapRouterUSDMTest is Test, IGenericButtonswapRouterErrors
         uint256 amountOutMin
     ) public {
         // Regenerating tokenB to mix up the token order
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         // Minting enough for minimum liquidity requirement
         poolUsdm = bound(poolUsdm, 10000, type(uint112).max - 3);
@@ -194,7 +194,7 @@ contract GenericButtonswapRouterUSDMTest is Test, IGenericButtonswapRouterErrors
         uint256 amountOutMin
     ) public {
         // Regenerating tokenB to mix up the token order
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         // Minting enough for minimum liquidity requirement
         poolUsdm = bound(poolUsdm, 10000, type(uint112).max);
@@ -242,7 +242,7 @@ contract GenericButtonswapRouterUSDMTest is Test, IGenericButtonswapRouterErrors
         uint256 amountInMax
     ) public {
         // Regenerating tokenB to mix up the token order
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         // Minting enough for minimum liquidity requirement
         poolUsdm = bound(poolUsdm, 10000, type(uint112).max);
@@ -293,7 +293,7 @@ contract GenericButtonswapRouterUSDMTest is Test, IGenericButtonswapRouterErrors
         uint256 amountInMax
     ) public {
         // Regenerating tokenB to mix up the token order
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         // Minting enough for minimum liquidity requirement
         poolUsdm = bound(poolUsdm, 10000, type(uint112).max);

--- a/test/GenericButtonswapRouter/V2/GenericButtonswapRouterAddLiquidityV2.t.sol
+++ b/test/GenericButtonswapRouter/V2/GenericButtonswapRouterAddLiquidityV2.t.sol
@@ -98,8 +98,8 @@ contract GenericButtonswapRouterAddLiquidityV2Test is Test, IGenericButtonswapRo
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         buttonswapV2FactoryHelper = new ButtonswapV2FactoryHelper();
         buttonswapV2Factory = new ButtonswapV2Factory(
@@ -597,8 +597,8 @@ contract GenericButtonswapRouterAddLiquidityV2Test is Test, IGenericButtonswapRo
         setupButtonswapV2FactoryParameters(plBps, feeBps);
 
         // Creating new tokens to ensure the pair does not exist
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         // Creating the addLiquidityParams
         addLiquidityParams.operation = ButtonswapOperations.Liquidity.SINGLE;
@@ -647,8 +647,8 @@ contract GenericButtonswapRouterAddLiquidityV2Test is Test, IGenericButtonswapRo
         setupButtonswapV2FactoryParameters(plBps, feeBps);
 
         // Re-assigning tokenA and tokenB to ensure random new pair
-        tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Creating random A1-B1 pair without initializing
         address pair = buttonswapV2Factory.createPair(address(tokenA), address(tokenB), plBps, feeBps);

--- a/test/GenericButtonswapRouter/V2/GenericButtonswapRouterRemoveLiquidityV2.t.sol
+++ b/test/GenericButtonswapRouter/V2/GenericButtonswapRouterRemoveLiquidityV2.t.sol
@@ -117,8 +117,8 @@ contract GenericButtonswapRouterRemoveLiquidityV2Test is Test, IGenericButtonswa
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
 
         buttonswapV2FactoryHelper = new ButtonswapV2FactoryHelper();
         buttonswapV2Factory = new ButtonswapV2Factory(

--- a/test/GenericButtonswapRouter/V2/GenericButtonswapRouterSwapV2.t.sol
+++ b/test/GenericButtonswapRouter/V2/GenericButtonswapRouterSwapV2.t.sol
@@ -90,8 +90,8 @@ contract GenericButtonswapRouterSwapV2Test is Test, IGenericButtonswapRouterErro
         (isPausedSetter, isPausedSetterPrivateKey) = makeAddrAndKey("isPausedSetter");
         (paramSetter, paramSetterPrivateKey) = makeAddrAndKey("paramSetter");
         (userA, userAPrivateKey) = makeAddrAndKey("userA");
-        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18);
-        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18);
+        tokenA = new MockRebasingERC20("TokenA", "TKNA", 18, 1e36);
+        tokenB = new MockRebasingERC20("TokenB", "TKNB", 18, 1e36);
         buttonswapV2FactoryHelper = new ButtonswapV2FactoryHelper();
         buttonswapV2Factory = new ButtonswapV2Factory(
             feeToSetter,
@@ -262,6 +262,7 @@ contract GenericButtonswapRouterSwapV2Test is Test, IGenericButtonswapRouterErro
         // Estimating how much input a trade would take and making amountInMax -1 lower
         uint256 expectedAmountIn = ButtonswapV2Library.getAmountIn(amountOut, poolA, poolB, plBps, feeBps);
         uint256 amountInMax = expectedAmountIn - 1;
+        vm.assume(amountInMax < tokenA.mintableBalance());
 
         // Creating swapSteps for single swap
         IGenericButtonswapRouter.SwapStep[] memory swapSteps = new IGenericButtonswapRouter.SwapStep[](1);

--- a/test/libraries/ButtonswapLibrary.t.sol
+++ b/test/libraries/ButtonswapLibrary.t.sol
@@ -127,8 +127,8 @@ contract ButtonswapLibraryTest is Test {
     function testFail_getLiquidityBalances_missingPair(bytes32 saltA, bytes32 saltB) public {
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A");
-        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B");
+        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A", 18);
+        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B", 18);
 
         // Call getReservoirs() without having created the pair
         ButtonswapLibrary.getLiquidityBalances(address(buttonswapFactory), address(tokenA), address(tokenB));
@@ -137,8 +137,8 @@ contract ButtonswapLibraryTest is Test {
     function test_getLiquidityBalances_emptyPair(bytes32 saltA, bytes32 saltB) public {
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Create the pair with the factory and two tokens
         buttonswapFactory.createPair(address(tokenA), address(tokenB));
@@ -172,8 +172,8 @@ contract ButtonswapLibraryTest is Test {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Create the pair with the factory and two tokens
         // First liquidity mint - determines price-ratios between the assets
@@ -205,8 +205,8 @@ contract ButtonswapLibraryTest is Test {
     function testFail_getPools_missingPair(bytes32 saltA, bytes32 saltB) public {
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A");
-        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B");
+        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A", 18);
+        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B", 18);
 
         // Call getPools() without having created the pair
         ButtonswapLibrary.getPools(address(buttonswapFactory), address(tokenA), address(tokenB));
@@ -215,8 +215,8 @@ contract ButtonswapLibraryTest is Test {
     function test_getPools_emptyPair(bytes32 saltA, bytes32 saltB) public {
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A");
-        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B");
+        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A", 18);
+        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B", 18);
 
         // Create the pair with the factory and two tokens
         buttonswapFactory.createPair(address(tokenA), address(tokenB));
@@ -237,8 +237,8 @@ contract ButtonswapLibraryTest is Test {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A");
-        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B");
+        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A", 18);
+        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B", 18);
 
         // Create the pair with the factory and two tokens
         // Minting liquidity in the pair
@@ -256,8 +256,8 @@ contract ButtonswapLibraryTest is Test {
     function testFail_getReservoirs_missingPair(bytes32 saltA, bytes32 saltB) public {
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A");
-        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B");
+        MockERC20 tokenA = new MockERC20{salt: saltA}("Token A", "TKN_A", 18);
+        MockERC20 tokenB = new MockERC20{salt: saltB}("Token B", "TKN_B", 18);
 
         // Call getReservoirs() without having created the pair
         ButtonswapLibrary.getReservoirs(address(buttonswapFactory), address(tokenA), address(tokenB));
@@ -266,8 +266,8 @@ contract ButtonswapLibraryTest is Test {
     function test_getReservoirs_emptyPair(bytes32 saltA, bytes32 saltB) public {
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Create the pair with the factory and two tokens
         buttonswapFactory.createPair(address(tokenA), address(tokenB));
@@ -299,8 +299,8 @@ contract ButtonswapLibraryTest is Test {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Create the pair with the factory and two tokens
         // First liquidity mint - determines price-ratios between the assets
@@ -471,7 +471,7 @@ contract ButtonswapLibraryTest is Test {
         // Creating all the tokens for the path
         address[] memory path = new address[](pathLength);
         for (uint256 idx = 0; idx < pathLength; idx++) {
-            MockERC20 token = new MockERC20("Token", "TKN");
+            MockERC20 token = new MockERC20("Token", "TKN", 18);
             path[idx] = address(token);
         }
 
@@ -507,7 +507,7 @@ contract ButtonswapLibraryTest is Test {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockERC20 token = new MockERC20("Token", "TKN");
+            MockERC20 token = new MockERC20("Token", "TKN", 18);
             path[idx] = address(token);
         }
 
@@ -549,7 +549,7 @@ contract ButtonswapLibraryTest is Test {
         // Creating all the tokens for the path
         address[] memory path = new address[](pathLength);
         for (uint256 idx = 0; idx < pathLength; idx++) {
-            MockERC20 token = new MockERC20("Token", "TKN");
+            MockERC20 token = new MockERC20("Token", "TKN", 18);
             path[idx] = address(token);
         }
 
@@ -585,7 +585,7 @@ contract ButtonswapLibraryTest is Test {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockERC20 token = new MockERC20("Token", "TKN");
+            MockERC20 token = new MockERC20("Token", "TKN", 18);
             path[idx] = address(token);
         }
 
@@ -623,7 +623,7 @@ contract ButtonswapLibraryTest is Test {
         // Creating all the tokens for the path
         address[] memory path = new address[](poolOutAmounts.length);
         for (uint256 idx; idx < path.length; idx++) {
-            MockERC20 token = new MockERC20("Token", "TKN");
+            MockERC20 token = new MockERC20("Token", "TKN", 18);
             path[idx] = address(token);
         }
 
@@ -659,8 +659,8 @@ contract ButtonswapLibraryTest is Test {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Creating the pair with poolA:poolB price ratio
         ButtonswapPair pair = createAndInitializePairRebasing(tokenA, tokenB, poolA, poolB);
@@ -716,8 +716,8 @@ contract ButtonswapLibraryTest is Test {
 
         // Creating the two tokens
         // Salts are used to fuzz unique addresses in arbitrary order
-        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18);
-        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18);
+        MockRebasingERC20 tokenA = new MockRebasingERC20{salt: saltA}("Token A", "TKN_A", 18, 1e36);
+        MockRebasingERC20 tokenB = new MockRebasingERC20{salt: saltB}("Token B", "TKN_B", 18, 1e36);
 
         // Creating the pair with poolA:poolB price ratio
         ButtonswapPair pair = createAndInitializePairRebasing(tokenA, tokenB, poolA, poolB);


### PR DESCRIPTION
## Changes:
- Updating Mock-Contracts dependency so that the unit tests now use the additional fields in
  - `MockERC20`: `decimals`
  - `MockRebasingERC20`: `totalSupply`

## Testing:
- Updated all the unit tests appropriately

## Reviewers:
N/A
